### PR TITLE
Widevine Deadlock at onKeyStatusChange callback aquiring its lock again

### DIFF
--- a/MediaSession.cpp
+++ b/MediaSession.cpp
@@ -30,6 +30,10 @@
 #define NYI_KEYSYSTEM "keysystem-placeholder"
 
 #include <refsw/b_secbuf.h>
+
+#include <functional>
+#include <thread>
+
 struct Rpc_Secbuf_Info {
     uint32_t type;
     size_t   size;
@@ -128,6 +132,11 @@ static const char* widevineKeyStatusToCString(widevine::Cdm::KeyStatus widevineS
 }
 
 void MediaKeySession::onKeyStatusChange()
+{
+    std::thread(std::bind(&MediaKeySession::deferredKeyStatusChange, this)).detach();
+}
+
+void MediaKeySession::deferredKeyStatusChange()
 {
     widevine::Cdm::KeyStatusMap map;
     if (widevine::Cdm::kSuccess != m_cdm->getKeyStatuses(m_sessionId, &map))

--- a/MediaSession.h
+++ b/MediaSession.h
@@ -87,6 +87,7 @@ public:
 
 private:
     void onKeyStatusError(widevine::Cdm::Status status);
+    void deferredKeyStatusChange();
 
 private:
     widevine::Cdm *m_cdm;


### PR DESCRIPTION
While stress testing playing YouTube's encrypted Movie, video stuck at playing, only the loading image keep rotating. WPEWebkit process waits on decrypt request via WPEFramework, but WPEFramework-OCDM-Widevine stuck at the deadlock trying to acquire Widevine's lock at onKeyStatusChange callback function. Another thread is created to call Widevine's getKeyStatuses function.