### PR TITLE
OpenCDM Update API Timeout/Lockup Issues.

### DIFF
--- a/MediaSession.cpp
+++ b/MediaSession.cpp
@@ -207,7 +207,10 @@ void MediaKeySession::Update(
     uint32_t f_cbKeyMessageResponse) {
   std::string keyResponse(reinterpret_cast<const char*>(f_pbKeyMessageResponse),
       f_cbKeyMessageResponse);
-  if (widevine::Cdm::kSuccess != m_cdm->update(m_sessionId, keyResponse))
+  widevine::Cdm::Status status = m_cdm->update(m_sessionId, keyResponse);
+  if (widevine::Cdm::kSuccess != status)
+     onKeyStatusError(status);
+  else
      onKeyStatusChange();
 }
 


### PR DESCRIPTION
OpenCdm::Update API goes into a wait state with infinite wait.
In cases where the License Server or application provides
an Incorrect License Response blob to the opencdm update API
the caller thread gets blocked infinitely.

Added OnKeyStatusError() in case of update fail.