### PR TITLE
Fix Widevine Session resource leak

### DIFF
--- a/MediaSystem.cpp
+++ b/MediaSystem.cpp
@@ -156,6 +156,9 @@ public:
         SessionMap::iterator index (_sessions.find(sessionId));
 
         if (index != _sessions.end()) {
+            // To clean up an underlying session resource, 
+            //  otherwise the session limit(eg,50) will hit eventually
+            index->second->Close();
             _sessions.erase(index);
         }
 


### PR DESCRIPTION
Widevine session resource has not been closed. If  WidevineH264Video test case has been tried more than 50 times, Widevine CDM returns the TOO_MANY_SESSION error at allocating a session.

```
---log cut
### 00:51:59.638 drm_wvoemcrypto_tl: DRM_WVOemCrypto_OpenSession - Unable to allocate an available session context
[ERROR:../../../core/src/crypto_session.cpp(685):Open] OEMCrypto_Open failed: 31, open sessions: 51, initialized: 1
[ERROR:../../../core/src/cdm_engine.cpp(142):OpenSession] CdmEngine::OpenSession: bad session init: 9
```