### PR TITLE
Do not notify about key statuses in case of success.

### DIFF
--- a/MediaSession.cpp
+++ b/MediaSession.cpp
@@ -222,9 +222,8 @@ void MediaKeySession::Update(
   g_lock.Lock();
   widevine::Cdm::Status status = m_cdm->update(m_sessionId, keyResponse);
   if (widevine::Cdm::kSuccess != status)
-     onKeyStatusError(status);
-  else
      onKeyStatusChange();
+
   g_lock.Unlock();
 }
 


### PR DESCRIPTION
Otherwise the notifications are sent twice. The callback will do that
in case of success so do that for failure case only.